### PR TITLE
Rename candle download methods

### DIFF
--- a/API/binance_api.py
+++ b/API/binance_api.py
@@ -155,5 +155,5 @@ class BinanceAPI(BirzaAPI):
 
 if __name__ == "__main__":
     bot = BinanceAPI(api_key=None, api_secret=None)
-    bot.download_candels_to_csv("BTC/USDT", start_date="2023-05-05T00:00:00Z", timeframe="1h")
+    bot.download_candles_to_csv("BTC/USDT", start_date="2023-05-05T00:00:00Z", timeframe="1h")
     df = bot.get_ohlcv("BTC/USDT")

--- a/API/birza_api.py
+++ b/API/birza_api.py
@@ -137,8 +137,8 @@ class BirzaAPI(ABC):
         """
         pass
 
-    def download_candels_to_csv(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z", 
-                               timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
+    def download_candles_to_csv(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
+                                timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
         """
         Download historical candle data and save to CSV.
 
@@ -259,8 +259,8 @@ class BirzaAPI(ABC):
         """
         pass
 
-    async def download_candels_to_csv_async(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z", 
-                               timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
+    async def download_candles_to_csv_async(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
+                                            timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
         """
         Asynchronously download historical candle data and save to CSV.
 

--- a/API/bybit_api.py
+++ b/API/bybit_api.py
@@ -129,9 +129,9 @@ class BybitAPI(BirzaAPI):
         except Exception as e:
             return self._handle_error(f"checking status of order {order_id}", e, {})
 
-    def download_candels_to_csv(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
-                               timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
-        return super().download_candels_to_csv(symbol, start_date, timeframe, save_folder)
+    def download_candles_to_csv(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
+                                timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
+        return super().download_candles_to_csv(symbol, start_date, timeframe, save_folder)
 
     # -------- async --------
 
@@ -207,9 +207,9 @@ class BybitAPI(BirzaAPI):
         except Exception as e:
             return await self._handle_error_async(f"checking status of order {order_id}", e, {})
 
-    async def download_candels_to_csv_async(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
-                               timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
-        return await super().download_candels_to_csv_async(symbol, start_date, timeframe, save_folder)
+    async def download_candles_to_csv_async(self, symbol: str, start_date: str = "2023-01-01T00:00:00Z",
+                                            timeframe: str = "1h", save_folder: str = "DATA") -> pd.DataFrame:
+        return await super().download_candles_to_csv_async(symbol, start_date, timeframe, save_folder)
 
     async def close_async(self):
         if self.async_exchange:
@@ -218,5 +218,5 @@ class BybitAPI(BirzaAPI):
 
 if __name__ == "__main__":
     bot = BybitAPI()
-    bot.download_candels_to_csv("BTC/USDT", start_date="2025-05-05T00:00:00Z", timeframe="1h")
+    bot.download_candles_to_csv("BTC/USDT", start_date="2025-05-05T00:00:00Z", timeframe="1h")
     # df = bot.get_ohlcv("BTC/USDT")

--- a/API/coinbase_api.py
+++ b/API/coinbase_api.py
@@ -152,5 +152,5 @@ class CoinbaseAPI(BirzaAPI):
 
 if __name__ == "__main__":
     bot = CoinbaseAPI(api_key=None, api_secret=None)
-    bot.download_candels_to_csv("BTC/USD", start_date="2023-05-05T00:00:00Z", timeframe="1h")
+    bot.download_candles_to_csv("BTC/USD", start_date="2023-05-05T00:00:00Z", timeframe="1h")
     df = bot.get_ohlcv("BTC/USD")


### PR DESCRIPTION
## Summary
- fix typo in BirzaAPI candle download methods and their async variants
- update Bybit, Binance, and Coinbase API classes to use new method names

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: numerous style violations across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68990cd6c7e8832abbd6c78de34360a9