### PR TITLE
Replace deprecated event loop retrieval

### DIFF
--- a/API/birza_api.py
+++ b/API/birza_api.py
@@ -279,7 +279,7 @@ class BirzaAPI(ABC):
         try:
             # Note: fetch_data would need an async version for full async support
             # For now, we'll use the synchronous version in an executor
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             df = await loop.run_in_executor(
                 None, 
                 lambda: fetch_data(exchange=exchange_name, symbol=symbol, start_date=start_date, timeframe=timeframe)


### PR DESCRIPTION
## Summary
- Use `asyncio.get_running_loop()` in `download_candels_to_csv_async` to replace deprecated `get_event_loop`

## Testing
- `python -m py_compile API/birza_api.py`
- `flake8 API/birza_api.py` *(fails: line length and other pre-existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68990cde19d0832a9bd6c5c593e78841